### PR TITLE
Simplify flake8 usage in CI workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -25,11 +25,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Lint with flake8
-        run: >
-          flake8 .
-          --max-line-length=100
-          --extend-ignore=E203,W503,E501,E261,E302,E303,W291,W391
-          --per-file-ignores="__init__.py:W391,F401,;local_api.py:F401;main.py:F401,F841;train_model.py:F401;test_ml.py:F401"
+        run: flake8 .
 
       - name: Test with pytest
         run: |

--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ class Data(BaseModel):
     hours_per_week: int = Field(..., example=40, alias="hours-per-week")
     native_country: str = Field(..., example="United-States", alias="native-country")
 
-path = None # TODO: enter the path for the saved encoder 
+
+path = None # TODO: enter the path for the saved encoder
 encoder = load_model(path)
 
 path = None # TODO: enter the path for the saved model 

--- a/ml/model.py
+++ b/ml/model.py
@@ -1,4 +1,3 @@
-import pickle
 from sklearn.metrics import fbeta_score, precision_score, recall_score
 from ml.data import process_data
 # TODO: add necessary import

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-﻿[flake8]
+[flake8]
 max-line-length = 100
 # Quiet noisy style rules for this starter:
 extend-ignore = E203,W503,E501,E261,E302,E303,W291,W391

--- a/test_commit.txt
+++ b/test_commit.txt
@@ -1,0 +1,1 @@
+This is a test commit file.


### PR DESCRIPTION
## Summary
- Simplify CI workflow's flake8 invocation to use project configuration
- Add a test commit file

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46429d4f8832f91b4c35e36aae6ac