### PR TITLE
Implement model utilities and data slice evaluation

### DIFF
--- a/ml/model.py
+++ b/ml/model.py
@@ -1,6 +1,9 @@
+import pickle
+
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import fbeta_score, precision_score, recall_score
+
 from ml.data import process_data
-# TODO: add necessary import
 
 # Optional: implement hyperparameter tuning.
 def train_model(X_train, y_train):
@@ -18,8 +21,9 @@ def train_model(X_train, y_train):
     model
         Trained machine learning model.
     """
-    # TODO: implement the function
-    pass
+    model = RandomForestClassifier(random_state=42)
+    model.fit(X_train, y_train)
+    return model
 
 
 def compute_model_metrics(y, preds):
@@ -58,8 +62,7 @@ def inference(model, X):
     preds : np.array
         Predictions from the model.
     """
-    # TODO: implement the function
-    pass
+    return model.predict(X)
 
 def save_model(model, path):
     """ Serializes model to a file.
@@ -71,13 +74,13 @@ def save_model(model, path):
     path : str
         Path to save pickle file.
     """
-    # TODO: implement the function
-    pass
+    with open(path, "wb") as file:
+        pickle.dump(model, file)
 
 def load_model(path):
     """ Loads pickle file from `path` and returns it."""
-    # TODO: implement the function
-    pass
+    with open(path, "rb") as file:
+        return pickle.load(file)
 
 
 def performance_on_categorical_slice(
@@ -116,12 +119,15 @@ def performance_on_categorical_slice(
     fbeta : float
 
     """
-    # TODO: implement the function
+    data_slice = data[data[column_name] == slice_value]
     X_slice, y_slice, _, _ = process_data(
-        # your code here
-        # for input data, use data in column given as "column_name", with the slice_value 
-        # use training = False
+        data_slice,
+        categorical_features=categorical_features,
+        label=label,
+        training=False,
+        encoder=encoder,
+        lb=lb,
     )
-    preds = None # your code here to get prediction on X_slice using the inference function
+    preds = inference(model, X_slice)
     precision, recall, fbeta = compute_model_metrics(y_slice, preds)
     return precision, recall, fbeta


### PR DESCRIPTION
## Summary
- add RandomForest model training and inference helpers
- support saving/loading models via pickle
- compute performance metrics on categorical data slices

## Testing
- `flake8 ml/model.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46ba00184832fba52491bcfdbaa42