### PR TITLE
Implement FastAPI inference endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,21 +27,18 @@ class Data(BaseModel):
     native_country: str = Field(..., example="United-States", alias="native-country")
 
 
-path = None # TODO: enter the path for the saved encoder
+path = os.path.join(os.path.dirname(__file__), "model", "encoder.pkl")
 encoder = load_model(path)
 
-path = None # TODO: enter the path for the saved model 
+path = os.path.join(os.path.dirname(__file__), "model", "model.pkl")
 model = load_model(path)
 
-# TODO: create a RESTful API using FastAPI
-app = None # your code here
+app = FastAPI()
 
-# TODO: create a GET on the root giving a welcome message
 @app.get("/")
 async def get_root():
     """ Say hello!"""
-    # your code here
-    pass
+    return {"message": "Hello from the API!"}
 
 
 # TODO: create a POST on a different path that does model inference
@@ -66,10 +63,10 @@ async def post_inference(data: Data):
         "native-country",
     ]
     data_processed, _, _, _ = process_data(
-        # your code here
-        # use data as data input
-        # use training = False
-        # do not need to pass lb as input
+        data,
+        categorical_features=cat_features,
+        training=False,
+        encoder=encoder,
     )
-    _inference = None # your code here to predict the result using data_processed
+    _inference = inference(model, data_processed)
     return {"result": apply_label(_inference)}


### PR DESCRIPTION
## Summary
- load trained model and encoder artifacts
- expose GET `/` welcome and POST `/data/` inference endpoints via FastAPI
- preprocess incoming data and return labeled prediction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4700e1220832f9754f93f6a342199